### PR TITLE
Fix image_z_match registration for uint16 inputs

### DIFF
--- a/tools/image_z_match.py
+++ b/tools/image_z_match.py
@@ -87,6 +87,11 @@ def plot_profiles(
 
 def estimate_z_shift_cross_correlation(ref_image: sitk.Image, target_image: sitk.Image) -> float:
     """Estimate z-shift using SimpleITK correlation metric in a translation-only registration."""
+    # Cast images to a floating type because the correlation metric does not
+    # support unsigned 16-bit inputs.
+    ref_image = sitk.Cast(ref_image, sitk.sitkFloat32)
+    target_image = sitk.Cast(target_image, sitk.sitkFloat32)
+
     registration = sitk.ImageRegistrationMethod()
     registration.SetMetricAsCorrelation()
     transform = sitk.TranslationTransform(ref_image.GetDimension())


### PR DESCRIPTION
## Summary
- cast reference and target images to float before running correlation-based registration
- prevent SimpleITK type errors when inputs are 16-bit TIFF stacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ff702824c8330848a2255ad61f3ea)